### PR TITLE
Use connection SteamIDs returned from the Steamworks API

### DIFF
--- a/RepoSteamNetworking/Networking/RepoNetworkSocketManager.cs
+++ b/RepoSteamNetworking/Networking/RepoNetworkSocketManager.cs
@@ -138,7 +138,7 @@ internal class RepoNetworkSocketManager : SocketManager
             {
                 userConnection.SetVerified();
                 
-                SendHandshakeStatus(header.Sender, true);
+                SendHandshakeStatus(identity.SteamId, true);
                 userConnection.StartModListValidation();
                 
                 return;
@@ -146,7 +146,7 @@ internal class RepoNetworkSocketManager : SocketManager
             
             Logging.Warn($"Handshake failed!");
             
-            SendHandshakeStatus(header.Sender, false);
+            SendHandshakeStatus(identity.SteamId, false);
             return;
         }
 
@@ -164,7 +164,7 @@ internal class RepoNetworkSocketManager : SocketManager
             }
         }
         
-        RepoSteamNetwork.OnHostReceivedMessage(bytes);
+        RepoSteamNetwork.OnHostReceivedMessage(bytes, connection, identity);
     }
 
     private void SendHandshakeStatus(SteamId target, bool success)

--- a/RepoSteamNetworking/Networking/RepoNetworkSocketManager.cs
+++ b/RepoSteamNetworking/Networking/RepoNetworkSocketManager.cs
@@ -8,7 +8,6 @@ using RepoSteamNetworking.Networking.Registries;
 using RepoSteamNetworking.Utils;
 using Steamworks;
 using Steamworks.Data;
-using HarmonyLib;
 
 namespace RepoSteamNetworking.Networking;
 
@@ -42,7 +41,7 @@ internal class RepoNetworkSocketManager : SocketManager
     private void AddNewSteamUserConnection(Connection connection, ConnectionInfo info)
     {
         var steamUserConnection = new SteamUserConnection(connection, info);
-        ulong steamId = Traverse.Create(info).Field<NetIdentity>("identity").Value.SteamId.Value;
+        var steamId = info.identity.SteamId.Value;
 
         var index = _steamUserConnections.Count;
         _connectionIdSteamUserConnectionLut[connection.Id] = index;

--- a/RepoSteamNetworking/Networking/SteamUserConnection.cs
+++ b/RepoSteamNetworking/Networking/SteamUserConnection.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Timers;
 using RepoSteamNetworking.API;
 using RepoSteamNetworking.Networking.Packets;
@@ -7,6 +6,7 @@ using RepoSteamNetworking.Networking.Unity;
 using RepoSteamNetworking.Utils;
 using Steamworks;
 using Steamworks.Data;
+using HarmonyLib;
 
 namespace RepoSteamNetworking.Networking;
 
@@ -14,6 +14,8 @@ public class SteamUserConnection : IEquatable<SteamUserConnection>
 {
     private string _clientKey = "";
     private Connection _connection;
+    private ConnectionInfo _info;
+    private NetIdentity _identity;
     private readonly Timer _timer;
 
     public uint ConnectionId => _connection.Id;
@@ -21,6 +23,8 @@ public class SteamUserConnection : IEquatable<SteamUserConnection>
     public SteamId SteamId { get; private set; }
     
     public ConnectionStatus Status { get; private set; }
+
+    public ConnectionState State => _info.State;
 
     public string UserName
     {
@@ -33,13 +37,25 @@ public class SteamUserConnection : IEquatable<SteamUserConnection>
         }
     } = "";
 
-    internal SteamUserConnection(Connection connection)
+    internal SteamUserConnection(Connection connection, ConnectionInfo info)
     {
         _connection = connection;
+        _info = info;
         _timer = new Timer(10000);
         _timer.AutoReset = false;
 
         Status = ConnectionStatus.Unverified;
+
+        _identity = Traverse.Create(info).Field<NetIdentity>("identity").Value;
+
+        if (_identity.IsSteamId)
+        {
+            SteamId = _identity.SteamId;
+        }
+        else
+        {
+            Logging.Error("NetIdentity was not a SteamID");
+        }
     }
 
     internal void StartVerification()
@@ -82,15 +98,14 @@ public class SteamUserConnection : IEquatable<SteamUserConnection>
         if (lobby.Id != packet.LobbyId)
             return false;
 
-        if (lobby.Members.Any(member => member.Id == packet.PlayerId))
+        if (SteamId == packet.PlayerId)
             return true;
         
         return false;
     }
 
-    internal void SetVerifiedWithSteamId(SteamId steamId)
+    internal void SetVerified()
     {
-        SteamId = steamId;
         Status = ConnectionStatus.Verified;
         
         Logging.Info($"Connection {ConnectionId} is now verified as Client {UserName}!");

--- a/RepoSteamNetworking/Networking/SteamUserConnection.cs
+++ b/RepoSteamNetworking/Networking/SteamUserConnection.cs
@@ -6,7 +6,6 @@ using RepoSteamNetworking.Networking.Unity;
 using RepoSteamNetworking.Utils;
 using Steamworks;
 using Steamworks.Data;
-using HarmonyLib;
 
 namespace RepoSteamNetworking.Networking;
 
@@ -46,7 +45,7 @@ public class SteamUserConnection : IEquatable<SteamUserConnection>
 
         Status = ConnectionStatus.Unverified;
 
-        _identity = Traverse.Create(info).Field<NetIdentity>("identity").Value;
+        _identity = info.identity;
 
         if (_identity.IsSteamId)
         {

--- a/RepoSteamNetworking/Networking/Unity/RepoNetworkingServer.cs
+++ b/RepoSteamNetworking/Networking/Unity/RepoNetworkingServer.cs
@@ -94,6 +94,8 @@ public class RepoNetworkingServer : MonoBehaviour
         var connected = SocketManager.UserConnections;
         foreach (var connection in connected)
         {
+            if (connection.State is not ConnectionState.Connected)
+                continue;
             var result = connection.SendMessage(message.GetBytes());
         }
     }
@@ -109,6 +111,12 @@ public class RepoNetworkingServer : MonoBehaviour
         if (!SocketManager.TryGetSteamUserConnection(target, out var connection))
         {
             Logging.Info($"No valid connection found for {target}!");
+            return;
+        }
+
+        if (connection.State is not ConnectionState.Connected)
+        {
+            Logging.Info($"Can't send message to unconnected client {target}");
             return;
         }
         

--- a/RepoSteamNetworking/RepoSteamNetworking.csproj
+++ b/RepoSteamNetworking/RepoSteamNetworking.csproj
@@ -62,7 +62,7 @@
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1" />
         <PackageReference Include="BepInEx.Core" Version="5.*" />
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.21" />
-        <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.1.2-ngd.0" />
+        <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.1.2-ngd.0" Publicize="true" />
     </ItemGroup>
 
     <Target Name="SetPluginVersion" BeforeTargets="AddGeneratedFile" DependsOnTargets="MinVer">


### PR DESCRIPTION
This will still have the client send their SteamID, but it will check if it matches their connection. Before it would check if the SteamID supplied matched _any_ lobby members SteamID. It will also check if the connection is valid before sending messages over the socket.

It still needs tested though, as I have only tested if it would launch and host.